### PR TITLE
(Fixed) Issues#20

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,7 +12,7 @@
 //
 //= require rails-ujs
 //= require activestorage
-//= require turbolinks
+// require turbolinks
 //= require jquery/dist/jquery.js
 //= require bootstrap/dist/js/bootstrap.js
 //= require_tree .

--- a/app/assets/javascripts/show_kml_map.js
+++ b/app/assets/javascripts/show_kml_map.js
@@ -1,0 +1,46 @@
+jQuery.gmapSearch = function ($, google, conf) {
+	var infoWindow,
+		ns = google.maps,
+		mapOptions = {
+			zoom: 14,
+			center: new ns.LatLng(35.6773166,139.8212672, 0),
+			mapTypeControl: false,
+			panControl: false,
+			streetViewControl: true,
+			zoomControl: true,
+			scaleControl: true,
+			overviewMapControl: true
+		},
+		map = new ns.Map($("#mapDiv")[0], mapOptions),
+		points = new ns.MVCArray(conf.points),
+		bounds = new ns.LatLngBounds();
+
+	var center1=0, center2=0, center3=0;	
+	points.forEach(function (point) {
+		center1 += point[1];
+		center2 += point[2];
+		center3 += point[3];
+
+		var myLatlng = new ns.LatLng(point[2], point[1]),
+			marker = new ns.Marker({
+				position: myLatlng,
+				map: map
+			});
+
+		bounds.extend(myLatlng);
+		ns.event.addListener(marker, 'click', function () {
+			if (!infoWindow) {
+				infoWindow  = new ns.InfoWindow();
+			}
+			infoWindow.setContent(point[0]);
+			infoWindow.open(map, marker);
+		});
+	});
+	center1 /= points.length
+	center2 /= points.length
+	center3 /= points.length
+
+	map.setCenter(new ns.LatLng(center2, center1));
+	map.fitBounds(bounds);
+
+};

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -21,14 +21,17 @@ class SitesController < ApplicationController
     @site = current_user.sites.build(team_id: current_user.keep_team_id)
   end
 
-  def confirm
+  def confirm    
     @site = Site.new(site_params)
-    load_kml(params[:file].path) if params[:file].present?
+    #load_kml(params[:file].path) if params[:file].present?
+    load_kml(site_params["kml"].path) if site_params["kml"].present?
   end
 
   def create
     @site = current_user.sites.build(site_params)
     @site.team_id ||= current_user.keep_team_id
+
+    byebug
 
     if params[:back]
       render :new
@@ -55,7 +58,8 @@ class SitesController < ApplicationController
     if (Site.find(params[:id]))
       @site.comments = Site.find(params[:id]).comments
     end
-    load_kml(params[:file].path) if params[:file].present?
+    #load_kml(params[:file].path) if params[:file].present?
+    load_kml(site_params["kml"].path) if site_params["kml"].present?
     render "confirm"
   end
 
@@ -103,7 +107,7 @@ class SitesController < ApplicationController
 
   private
   def site_params
-    p = params.require(:site).permit(:team_id, :name, :address, :latitude, :longtitude, :memo, :tag_list, { label_ids: [] }, { comments_str: [] }, { comments: [] })
+    p = params.require(:site).permit(:team_id, :name, :address, :latitude, :longtitude, :memo, :kml, :kml_cache, :tag_list, { label_ids: [] }, { comments_str: [] }, { comments: [] })
     p[:tag_list] = p[:tag_list].split(/[[:space:]]/).select {|li| li.length > 0}
     p[:label_ids] = p[:label_ids].select { |li| li.length > 0 }
     if p[:comments_str] && p[:comments_str].length > 0

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,5 +1,5 @@
 class Comment < ApplicationRecord
-  validates :content, presence: true, length: {maximum: 1024}
+  validates :content, presence: true, length: {maximum: 4096}
 
   belongs_to :user
   belongs_to :site

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -12,4 +12,6 @@ class Site < ApplicationRecord
 
   has_many :site_labellings, dependent: :destroy, foreign_key: 'site_id'
   has_many :labels, through: :site_labellings, source: :label
+
+  mount_uploader :kml, ImageUploader
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -2,7 +2,7 @@ class Site < ApplicationRecord
   acts_as_taggable
 
   validates :name, presence: true, length: {maximum: 128}
-  validates :address, presence: true, length: {maximum: 255}
+  validates :address, length: {maximum: 255}
   validates :memo, length: {maximum: 255}
 
   has_many :comments, dependent: :destroy

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%#= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag 'application' %>
+    <script src="<%= "http://maps.google.com/maps/api/js?key=#{ENV['GOOGLEMAP_API_KEY']}&sensor=false" %>"></script>
   </head>
 
   <body>

--- a/app/views/sites/_form.html.erb
+++ b/app/views/sites/_form.html.erb
@@ -1,7 +1,10 @@
 <%= form_with(model: site,  url: choose_new_or_edit_confirm, method: :post, multipart: true, local: true) do |form| %>
 
 <div class="container_article border border-dark">
-    <h3><i class="fa fa-info-circle" aria-hidden="true"></i><%= I18n.t('views.labels.site_show_basic_attributes_block') %></h3>
+    <h3>
+      <i class="fa fa-info-circle" aria-hidden="true"></i></i>&nbsp;
+      <%= I18n.t('views.labels.site_show_basic_attributes_block') %>
+    </h3>
 
     <% if site.errors.any? %>
       <div id="error_explanation">
@@ -51,10 +54,12 @@
       <td><%= form.text_field :tag_list, id: '', size: 48, class: "m-1 p-1" %></td>
     </tr>
     <tr>
-<!--      <td align="right"><%#= I18n.t('views.labels.load_kml') %></td> -->
-<!--      <td><%#= file_field_tag :file, class: "p-1 btn-sm" %></td>  -->
-          <td align="right"><%= form.label :kml, I18n.t('views.labels.load_kml') %></td>
-          <td><%= form.file_field :kml, class: "p-1 btn-sm" %></td>
+      <td align="right"><%= form.label :kml, I18n.t('views.labels.site_kml') %></td>
+      <td>
+        <%= site.kml.path.split("/").last if site.kml.path %><BR>
+        <%= form.file_field :kml, class: "p-1 btn-sm" %>
+        <%= form.hidden_field :kml_cache %>
+      </td>
     </tr>    
 
     <tr><td>

--- a/app/views/sites/_form.html.erb
+++ b/app/views/sites/_form.html.erb
@@ -51,8 +51,10 @@
       <td><%= form.text_field :tag_list, id: '', size: 48, class: "m-1 p-1" %></td>
     </tr>
     <tr>
-      <td align="right"><%= I18n.t('views.labels.load_kml') %></td>
-      <td><%= file_field_tag :file, class: "p-1 btn-sm" %></td>
+<!--      <td align="right"><%#= I18n.t('views.labels.load_kml') %></td> -->
+<!--      <td><%#= file_field_tag :file, class: "p-1 btn-sm" %></td>  -->
+          <td align="right"><%= form.label :kml, I18n.t('views.labels.load_kml') %></td>
+          <td><%= form.file_field :kml, class: "p-1 btn-sm" %></td>
     </tr>    
 
     <tr><td>

--- a/app/views/sites/confirm.html.erb
+++ b/app/views/sites/confirm.html.erb
@@ -6,6 +6,8 @@
   <%= form.hidden_field :address %>
 <%#= form.hidden_field :label_ids %>
   <%= form.hidden_field :memo %>
+  <%= form.hidden_field :kml %>
+  <%= form.hidden_field :kml_cache %>
   <%= form.hidden_field :tag_list, value: @site.tag_list+@tags_str %>
 
   <table border=1 bgcolor="whitesmoke">

--- a/app/views/sites/confirm.html.erb
+++ b/app/views/sites/confirm.html.erb
@@ -13,7 +13,13 @@
   <table border=1 bgcolor="whitesmoke">
     <tr>
       <td align="right"><%= form.label I18n.t('views.labels.site_name'), class: "font-weight-bolder m-1 p-1" %></td>      
-      <td><%= @site.name %></td>      
+      <td>
+        <% if @document_name.present? %>
+          <div class="text-success"><%= @document_name %></div>
+        <% else %>
+          <%= @site.name %>
+        <% end %>
+      </td>      
     </tr>
     <tr>
       <td align="right"><%= form.label I18n.t('views.labels.site_address'), class: "font-weight-bolder m-1 p-1" %></td>
@@ -45,11 +51,21 @@
 
     <tr>
       <td align="right"><%= form.label I18n.t('views.labels.site_memo'), class: "font-weight-bolder m-1 p-1" %></td>
-      <td><%= @site.memo %></td>            
+      <td>
+        <% if @document_description.present? %>
+          <div class="text-success"><%= @document_description %></div>
+        <% else %>
+          <%= @site.memo %>
+        <% end %>
+      </td>            
     </tr>
     <tr>
       <td align="right"><%= form.label I18n.t('views.labels.site_hashtag'), class: "font-weight-bolder m-1 p-1" %></td>
       <td><%= @site.tag_list %>&nbsp;<div class="text-success"><%= @tags_str.join(" ") if @tags_str.present? %></div></td>
+    </tr>
+    <tr>
+      <td align="right"><%= form.label I18n.t('views.labels.site_kml'), class: "font-weight-bolder m-1 p-1" %></td>
+      <td><%= @site.kml.path.split("/").last if @site.kml.path.present? %></td>
     </tr>
 
     <% if @comments_str.present? %>

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -76,12 +76,34 @@
     <a name="maps"></a>
     <section class="site_show_map_block">  
       <div class="row">
-        <div class="col-12">
-          <iframe frameborder="0" 
-                    style="border:0; width: 300px; height: 200px" 
-                    src="https://maps.google.co.jp/maps?output=embed&q=<%= @site.address%>">
-          </iframe>
-        </div>
+
+        <% if @site.address.present? %>
+          <div class="col-auto">
+            <span class="text-monospace"><%= I18n.t('views.labels.site_address') %></span><BR>
+            <iframe frameborder="0" 
+                      style="border:0; width: 400px; height: 300px" 
+                      src="https://maps.google.co.jp/maps?output=embed&q=<%= @site.address%>">
+            </iframe>
+          </div>
+        <% end %>
+
+        <% if @points %>
+          <div class="col-auto">
+            <span class="text-monospace"><%= I18n.t('views.labels.site_kml') %></span><BR>
+            <div id="mapDiv" style="width:400px; height:300px;"></div>
+            <input name="arr_json_points" type="hidden" value="<%= @points %>" class="arr_json_points">
+            <script>
+              jQuery(function($) {
+                var arrJsonPoints=$('.arr_json_points').val();
+                var conf={
+                  points: JSON.parse(arrJsonPoints)
+                };
+                $.gmapSearch($, google, conf);
+              });
+            </script>
+          </div>
+        <% end %>
+
       </div>
     </section>
     <!-- mapブロック end -->
@@ -117,7 +139,7 @@
         <% @image_posts.each do |post| %>
           <div class="col-auto">
             <div class="site_show_menu_on_image m-1 p-1">
-              <%= image_tag(post.image_url, class:'site_show_image') %>
+              <%= image_tag(post.image_url, class:"site_show_image", alt: "#{File.basename(post.image.path, '.*')}" ) %>
               <% if (current_user.id == post.user_id) || (current_user.id == current_user.keep_team.owner_id) %>
                 <div class="site_show_menu">
                   <%= link_to '×', image_post_path(id: post.id), method: :delete, data: {confirm: I18n.t('views.messages.really_want_to_delete') } %>

--- a/app/views/statics/functions.html.erb
+++ b/app/views/statics/functions.html.erb
@@ -35,8 +35,8 @@
   <div class="card-header"><span class="font-weight-bold"><i class="fa fa-truck fa-lg" aria-hidden="true"></i>&nbsp;&nbsp;共有範囲（チーム）の作成</span></div>
     <div class="card-body">
       システムにログインした利用者は、自分のチームを新規に作成し、アカウント<BR>
-      を持つメンバーをチームに招待することができます。チームを使用することで、<BR>
-      登録するサイト情報の共有範囲を設定することが可能です。
+      を持つメンバーをチームに招待することができます。本ツールでは、作成した<BR>
+      チームが登録するサイト情報の共有範囲となります。
     </div>
   </div>
 </div>
@@ -44,10 +44,12 @@
 <div class="card m-3" style="width:40rem;">
   <div class="card-header"><span class="font-weight-bold"><i class="fa fa-truck fa-lg" aria-hidden="true"></i>&nbsp;&nbsp;Google KMLファイルの情報活用</span></div>
     <div class="card-body">
-      サイト作成時には、Googleマイマップなどから生成可能なKMLファイルの活用が<BR>
-      可能です。KMLファイルを読み込むと、経由地点の表題がハッシュタグ、説明が<BR>
-      コメントとして取り込まれるため、絞込み検索をおこなうことが可能となります。<BR>
-    </div>
+      サイト作成時には、<a href="https://www.google.co.jp/intl/ja/maps/about/mymaps/" target="_blank">Googleマイマップ</a>などから生成可能なKMLファイルの活用が<BR>
+      可能です。新規作成画面からKMLファイルを読み込むと、プレイスマーク<BR>
+      (Placemark)の名称(name)を本ツールのハッシュタグ、説明（description）を<BR>
+      コメントとして取り込み、絞込み検索をおこなうことが可能となります。<BR>
+      さらに、地点（Point）の緯度経度（coordinates）と説明(description)がマップ上に<BR>
+      バルーンとして表示されます。 </div>
   </div>
 </div>
 

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -25,3 +25,15 @@ CarrierWave.configure do |config|
       config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/smr-development'
   end
 end
+
+# permit japanese filename
+CarrierWave::SanitizedFile.sanitize_regexp = /[^[:print:]\.\-\+]/
+
+def filename
+  "#{secure_token}.#{file.extension}" if original_filename.present?
+end
+
+def secure_token
+  var = :"@#{mounted_as}_secure_token"
+  model.instance_variable_get(var) or model.instance_variable_set(var, SecureRandom.uuid)
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -254,6 +254,7 @@ en:
       link_add_image: 'Add image'
       link_site_show: 'Show site'
       link_site_new: 'New site'
+      site_kml: 'Google KML file'
       site_index: 'Site index'
       site_index_index: 'Index'
       site_index_edit: 'Edit'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -205,7 +205,6 @@ ja:
     pm: 午後
   views:
     labels:
-      load_kml: 'KMLファイル..'
       link_menu_app_name: 'SmoothRunning - サイト情報共有ツール'
       link_menu_my_team: 'マイチーム'
       link_menu_new_team: 'あたらしくチームを作る'
@@ -246,6 +245,7 @@ ja:
       link_add_image: '画像を追加する'
       link_site_show: '詳細'      
       link_site_new: '新規作成'
+      site_kml: 'Google KMLファイル'
       site_index: 'サイト情報'
       site_index_index: '一覧'
       site_index_edit: '編集'

--- a/db/migrate/20210508222335_add_kml_to_sites.rb
+++ b/db/migrate/20210508222335_add_kml_to_sites.rb
@@ -1,0 +1,5 @@
+class AddKmlToSites < ActiveRecord::Migration[5.2]
+  def change
+    add_column :sites, :kml, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_05_064148) do
+ActiveRecord::Schema.define(version: 2021_05_08_222335) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -71,6 +71,7 @@ ActiveRecord::Schema.define(version: 2021_05_05_064148) do
     t.datetime "updated_at", null: false
     t.bigint "user_id"
     t.bigint "team_id"
+    t.string "kml"
     t.index ["team_id"], name: "index_sites_on_team_id"
     t.index ["user_id"], name: "index_sites_on_user_id"
   end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe Comment, type: :model do
         comment = Comment.create(content: _content, user_id: @user.id, site_id: @site.id)
         expect(comment).not_to be_valid
       end
-      it 'コンテンツが1024文字より長いと作成できない' do
-        _content=""; 1025.times.each { _content += (('a'..'z').to_a.sample) }
+      it 'コンテンツが4096文字より長いと作成できない' do
+        _content=""; 5000.times.each { _content += (('a'..'z').to_a.sample) }
         comment = Comment.create(content: _content, user_id: @user.id, site_id: @site.id)
         expect(comment).not_to be_valid
       end
@@ -27,8 +27,8 @@ RSpec.describe Comment, type: :model do
         @comment.update(content: _content)
         expect(@comment).not_to be_valid
       end
-      it 'コンテンツが1024文字より長いと更新できない' do
-        _content=""; 1025.times.each { _content += (('a'..'z').to_a.sample) }
+      it 'コンテンツが4096文字より長いと更新できない' do
+        _content=""; 5000.times.each { _content += (('a'..'z').to_a.sample) }
         @comment.update(content: _content)
         expect(@comment).not_to be_valid
       end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe Site, type: :model do
         site = Site.create(name: _name, address: _address, user_id: @user.id, team_id: @team.id)
         expect(site).not_to be_valid
       end
-      it 'サイト住所が空' do
+      # 住所が空でもサイトを登録させるよう変更
+      xit 'サイト住所が空' do
         _name="name"; _address="";
         site = Site.create(name: _name, address: _address, user_id: @user.id, team_id: @team.id)
         expect(site).not_to be_valid

--- a/spec/system/site_spec.rb
+++ b/spec/system/site_spec.rb
@@ -355,7 +355,8 @@ RSpec.describe 'サイト機能のテスト', type: :system do
       expect(page).to have_content "Nameは128文字以内で入力してください"  
     end
 
-    it '新規作成で住所が空だと作成できないこと' do
+    # 住所が空でもサイトを登録させるよう変更
+    xit '新規作成で住所が空だと作成できないこと' do
       #Sign in 画面に遷移
       visit new_user_session_path
       sleep(0.1)
@@ -594,7 +595,7 @@ RSpec.describe 'サイト機能のテスト', type: :system do
       expect(links[1][:href]).not_to have_content "comments/#{@comment02.id}"
     end
 
-    it '1024文字以上のコメントを入力すると追加できないこと' do
+    it '4096文字以上のコメントを入力すると追加できないこと' do
       #Sign in 画面に遷移
       visit new_user_session_path
       sleep(0.1)
@@ -628,7 +629,7 @@ RSpec.describe 'サイト機能のテスト', type: :system do
       expect(page).to have_content I18n.t('views.labels.site_show')
 
       #遷移先詳細画面でコメントを入力し追加ボタン押下
-      _comment=""; 1025.times.each { _comment += (('a'..'z').to_a.sample) }
+      _comment=""; 5000.times.each { _comment += (('a'..'z').to_a.sample) }
       fill_in "comment[content]", with: _comment
       click_on "commit"
       sleep(0.1)


### PR DESCRIPTION
 - サイトモデルにkmlカラム追加し、carrierwaveを使用して利用者アップロードしたファイルをS3に保存
    - 読み込んだkmlのname/descriptionをサイト名称/メモに保存
    
    - 読み込んだPointのname/description/Point(coordinates)をもとに２枚目の地図を描画
    - 住所の登録が必須ではないよう修正（住所が無い場合は１枚目のマップを表示しない）
    - コメントの最大文字数を4096に拡大